### PR TITLE
test and document the behavior of arrayref

### DIFF
--- a/lib/Ref/Explicit.pm
+++ b/lib/Ref/Explicit.pm
@@ -55,6 +55,28 @@ But this makes the syntax ugly and the intent unclear. With C<arrayref> the abov
     ...
   } @values;
 
+B<WARNING>: C<arrayref> will, in most cases, create references to the original 
+variables, which means that modifying the original variable will impact the 
+copy, and vice versa.
+
+    my @array = ( 1, 2, 3, 4 );
+    my $copy = arrayref @array;
+
+    $array[0]  = 'a';   # $copy->[0] is now 'a'
+    $copy->[1] = 'b';   # $array[1] is now 'b'
+
+    my %hash = ( 'a' => 'b', 'c' => 'd' );
+    $copy = arrayref %hash;
+
+    $hash{a}   = 'e';  # $copy->[4] is now 'e'!
+    $copy->[1] = 'f';  # $hash{a} is now 'f'!
+
+    my( $one, $three ) = qw/ one three /;
+    $copy = arrayref $one, '2', $three;
+
+    $three     = 'trois';  # $copy->[2] is now 'trois'!
+    $copy->[0] = 'un';     # $one is now 'un'!
+
 =func C<hashref> (@VALUES)
 
 Return a hash reference containing the values passed as arguments. Useful within C<map>-like expressions that return a list of hashrefs. Consider the following example:
@@ -65,6 +87,9 @@ Return a hash reference containing the values passed as arguments. Useful within
 The C<+> (plus) sign tells the parser to evaluate the code in curly brackets as an anonymous hashref rather than as a block. With C<hashref> this can be written more elegantly as:
 
   my @persons = map { hashref name => $_, industry => 'Movies' } @names;
+
+The C<hashref> function always make a copy of the original values passed, so it doesn't
+have the peculiar corner-case behavior of C<arrayref>.
 
 =head1 CAVEATS
 

--- a/t/copies.t
+++ b/t/copies.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use Ref::Explicit;
+
+subtest 'arrayref' => sub {
+    my @array = ( 1..4 );
+
+    my $copy = arrayref @array;
+
+    is_deeply $copy => \@array, 'same content';
+
+    $array[1] = 'changed';
+
+    is $copy->[1] => 'changed', 'the copy is an alias to the original array';
+
+    $copy = arrayref map { $_ } @array;
+
+    $array[2] = 'changed';
+
+    is $copy->[2] => 3, 'the copy is not an alias to the original array';
+
+    my %hash = ( 'a'..'d' );
+
+    $copy = arrayref %hash;
+
+    $hash{a} = 'changed';
+
+    is_deeply [ sort @$copy ] => [ qw/ a c changed d/ ], 'hash copy is an alias';
+
+    my $one   = 'one';
+    my $three = 'three';
+
+    $copy = arrayref $one, 2, $three;
+
+    $three = 'trois';
+
+    is_deeply $copy => [ 'one', 2, 'trois' ], 'scalar copy is an alias';
+
+    my @first  = ( 1..3 );
+    my @second = ( 100..103 );
+
+    $copy = arrayref @first, @second;
+
+    $copy->[-1] = 'a';
+    is $second[-1] => 'a', 'copy is an alias';
+
+    $first[0] = 'b';
+    is $copy->[0] => 'b', 'goes both way';
+
+
+
+};
+
+subtest 'hashref' => sub {
+    my %hash = ( 1..4 );
+
+    my $copy = hashref %hash;
+
+    is_deeply $copy => \%hash, 'same content';
+
+    $hash{1} = 'changed';
+
+    isnt $copy->{1} => 'changed', 'the copy is not an alias to the original hash';
+};
+
+


### PR DESCRIPTION
I'm documenting the sometime surprising behavior of `arrayref`.  If you want to keep the function more intuitive, you might want to change the code to do

```
    sub arrayref {  [ @_ ] }
```

instead. Not as fast, but more sane behavior. :-)
